### PR TITLE
Enabling the creation of large WAV files

### DIFF
--- a/src/afaligner/__init__.py
+++ b/src/afaligner/__init__.py
@@ -192,7 +192,7 @@ def build_sync_map(
             audio_name = get_name_from_path(audio_path)
             output_audio_name = os.path.join(sync_map_audio_path_prefix, audio_name)
             audio_wav_path = os.path.join(tmp_dir, f'{drop_extension(audio_name)}_audio.wav')
-            subprocess.run(['ffmpeg', '-n', '-i', audio_path, audio_wav_path])
+            subprocess.run(['ffmpeg', '-n', '-i', audio_path, '-rf64', 'auto', audio_wav_path])
 
             audio_mfcc_sequence = np.ascontiguousarray(
                 AudioFileMFCC(audio_wav_path).all_mfcc.T[:, 1:]


### PR DESCRIPTION
If the audio of a book is too long, the creation of the corresponding WAV file will fail in ffmpeg due to a limitation in the format itself. Enabling the creation of very large WAV files in ffmpeg is possible by passing the flag `-rf64` set to `auto`. See https://superuser.com/a/1523649

