### PR TITLE
fix bug unicode decode error when processing the text

### DIFF
--- a/src/afaligner/__init__.py
+++ b/src/afaligner/__init__.py
@@ -86,8 +86,8 @@ def align(
 
     os.makedirs(tmp_dir, exist_ok=True)
     
-    text_paths = (os.path.join(text_dir, f) for f in sorted(os.listdir(text_dir)))
-    audio_paths = (os.path.join(audio_dir, f) for f in sorted(os.listdir(audio_dir)))
+    text_paths = (os.path.join(text_dir, f) for f in sorted(os.listdir(text_dir)) if not f.startswith('.'))
+    audio_paths = (os.path.join(audio_dir, f) for f in sorted(os.listdir(audio_dir)) if not f.startswith('.'))
 
     sync_map = build_sync_map(
         text_paths, audio_paths, tmp_dir,


### PR DESCRIPTION
I have all the audio files and text files ready in the correct library structure as described. Files are txt utf-8.

However I keep getting this error: UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 3131: invalid start byte

this is an error when the build_sync_map function trying to read the non text file as a text file. the non text file could be some system files, like .DS_store in macOS system. 

so we should ignore  this system files when scan the text files and audio file  use the code below

text_paths = (os.path.join(text_dir, f) for f in sorted(os.listdir(text_dir)) if not f.startswith('.'))
audio_paths = (os.path.join(audio_dir, f) for f in sorted(os.listdir(audio_dir)) if not f.startswith('.'))
